### PR TITLE
Fix Flannel node naming to match kubelet registration

### DIFF
--- a/modules/service/rosequartz/network.nix
+++ b/modules/service/rosequartz/network.nix
@@ -35,6 +35,9 @@ in
       storageBackend = "kubernetes";
       network = config.services.kubernetes.clusterCidr;
       kubeconfig = flannelKubeconfig;
+      # clan sets meta.domain = "thecluster.io", making fqdnOrHostName return
+      # "pik8s4.thecluster.io", but kubelet registers nodes with the short name.
+      nodeName = config.networking.hostName;
     };
     services.kubernetes.kubelet.cni.config = lib.mkDefault [
       {


### PR DESCRIPTION
When `clan` sets `meta.domain`, Flannel's `fqdnOrHostName` constructs a FQDN (e.g., `pik8s4.thecluster.io`). Kubelet, however, registers nodes using only the short hostname (e.g., `pik8s4`). This mismatch can lead to networking issues.

This change explicitly sets Flannel's `nodeName` to `config.networking.hostName` to ensure it uses the short identifier, resolving the discrepancy with how kubelet registers the node.
