### PR TITLE
Bootstrap coredns + Flux in rosequartz via inoculant

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -381,6 +381,27 @@
     "flake-utils_3": {
       "inputs": {
         "systems": [
+          "inoculant",
+          "systems"
+        ]
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_4": {
+      "inputs": {
+        "systems": [
           "nixos-facter",
           "systems"
         ]
@@ -396,6 +417,27 @@
       "original": {
         "owner": "numtide",
         "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "globset": {
+      "inputs": {
+        "nixpkgs-lib": [
+          "inoculant",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1756146523,
+        "narHash": "sha256-dn8WNgwVQe0xBJ/d4CiRRcEVSgNclG6WSbqFEf6V024=",
+        "owner": "pdtpartners",
+        "repo": "globset",
+        "rev": "62da8904981f01dc7c97f56c3ea4f131a8393411",
+        "type": "github"
+      },
+      "original": {
+        "owner": "pdtpartners",
+        "repo": "globset",
         "type": "github"
       }
     },
@@ -428,6 +470,28 @@
           "flake-utils"
         ],
         "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1770585520,
+        "narHash": "sha256-yBz9Ozd5Wb56i3e3cHZ8WcbzCQ9RlVaiW18qDYA/AzA=",
+        "owner": "nix-community",
+        "repo": "gomod2nix",
+        "rev": "1201ddd1279c35497754f016ef33d5e060f3da8d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "gomod2nix",
+        "type": "github"
+      }
+    },
+    "gomod2nix_3": {
+      "inputs": {
+        "flake-utils": "flake-utils_3",
+        "nixpkgs": [
+          "inoculant",
           "nixpkgs"
         ]
       },
@@ -491,6 +555,38 @@
       "original": {
         "owner": "numtide",
         "repo": "hwinfo",
+        "type": "github"
+      }
+    },
+    "inoculant": {
+      "inputs": {
+        "flake-parts": [
+          "flake-parts"
+        ],
+        "globset": "globset",
+        "gomod2nix": "gomod2nix_3",
+        "nix2container": "nix2container_3",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "systems": [
+          "systems"
+        ],
+        "treefmt-nix": [
+          "treefmt-nix"
+        ]
+      },
+      "locked": {
+        "lastModified": 1784257530,
+        "narHash": "sha256-uRXZyseCSC/hrxluEWBLb9uvLmiqd3JMzmF3vwOSZks=",
+        "owner": "UnstoppableMango",
+        "repo": "inoculant",
+        "rev": "d835ce09993a7f4262ecb24c609f653125a939c3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "UnstoppableMango",
+        "repo": "inoculant",
         "type": "github"
       }
     },
@@ -801,6 +897,27 @@
         "type": "github"
       }
     },
+    "nix2container_3": {
+      "inputs": {
+        "nixpkgs": [
+          "inoculant",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1775487831,
+        "narHash": "sha256-2lguQpLPQaxpQCJjXhmEEAfabwsAhkP29Z7fgLzHARA=",
+        "owner": "nlewo",
+        "repo": "nix2container",
+        "rev": "76be9608a7f4d6c985d28b0e7be903ae2547df3e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nlewo",
+        "repo": "nix2container",
+        "type": "github"
+      }
+    },
     "nixd": {
       "inputs": {
         "flake-parts": [
@@ -865,7 +982,7 @@
         "disko": [
           "disko"
         ],
-        "flake-utils": "flake-utils_3",
+        "flake-utils": "flake-utils_4",
         "hwinfo": "hwinfo",
         "nixpkgs": [
           "nixpkgs"
@@ -1076,6 +1193,7 @@
         "flake-utils": "flake-utils_2",
         "gomod2nix": "gomod2nix_2",
         "home-manager": "home-manager",
+        "inoculant": "inoculant",
         "mynix": "mynix",
         "nixos-anywhere": "nixos-anywhere",
         "nixos-facter": "nixos-facter",

--- a/flake.nix
+++ b/flake.nix
@@ -95,6 +95,16 @@
       };
     };
 
+    inoculant = {
+      url = "github:UnstoppableMango/inoculant";
+      inputs = {
+        nixpkgs.follows = "nixpkgs";
+        systems.follows = "systems";
+        flake-parts.follows = "flake-parts";
+        treefmt-nix.follows = "treefmt-nix";
+      };
+    };
+
     dotfiles = {
       url = "github:unstoppablemango/dotfiles";
       inputs = {

--- a/modules/service/rosequartz/AGENTS.md
+++ b/modules/service/rosequartz/AGENTS.md
@@ -34,7 +34,7 @@ Multi-master HA Kubernetes cluster clan service. Targets Raspberry Pi 4B control
 | `worker.nix` | NixOS config for worker nodes (kubelet only) |
 | `pki.nix` | cfssl-based PKI machinery; `cluster.rosequartz.pki.*` options |
 | `network.nix` | Flannel CNI setup |
-| `flux.nix` | Optional Flux bootstrap static pod (WIP) |
+| `flux.nix` | Optional coredns + Flux bootstrap via `inputs.inoculant` (`cluster.rosequartz.fluxBootstrap.enable`) |
 
 ## NixOS services.kubernetes Options
 
@@ -241,5 +241,5 @@ All under `cluster.rosequartz.*` (set in the `nixosModule` by the clan service):
 - `localNode` in `control-plane.nix` is derived via `findFirst` matching `advertiseAddress`. If IP mismatches the node list, evaluation throws.
 - `etcd.initialCluster` defaults to all nodes. Override when replacing a member (`initialClusterState = "existing"`).
 - Keepalived `state = "BACKUP"` on all nodes — no `MASTER`; highest `priority` wins. Adjust `keepalivedPriority` per machine in inventory if needed.
-- `flux.nix` depends on `inputs.a2b` (not in this flake yet). WIP — do not import without that input.
+- `flux.nix` bootstraps coredns + Flux via `inputs.inoculant`'s NixOS module. Inoculant's own cert generation relies on nixpkgs' certmgr/easyCerts flow, which rosequartz doesn't run — `flux.nix` force-overrides `services.kubernetes.pki.certs.inoculant` with a rosequartz-issued cert instead. CoreDNS manifests are harvested from `config.services.kubernetes.addonManager.{addons,bootstrapAddons}` (populated by nixpkgs' `addons.dns` module, which is mkDefault-enabled but never applied since `addonManager.enable = false`) rather than hand-written.
 - Shared certs (`share = true`) are generated once and deployed to all machines. Per-machine certs (`share = false`) are generated separately per machine.

--- a/modules/service/rosequartz/control-plane.nix
+++ b/modules/service/rosequartz/control-plane.nix
@@ -38,6 +38,7 @@ in
     ./kubeconfig.nix
     ./network.nix
     ./pki.nix
+    ./flux.nix
   ];
 
   options.cluster.rosequartz = {

--- a/modules/service/rosequartz/flux.nix
+++ b/modules/service/rosequartz/flux.nix
@@ -1,5 +1,3 @@
-# WIP
-
 {
   config,
   lib,
@@ -35,144 +33,54 @@ let
 
   # Bundled the way `flux bootstrap` lays them out, so this directory can be
   # copied verbatim into the-cluster's clusters/rosequartz/flux-system once
-  # the cluster is self-managing.
-  manifests = pkgs.runCommand "rosequartz-flux-manifests" { } ''
+  # the cluster is self-managing. inoculant applies raw manifest files
+  # directly, so this is handed to it via `manifestFiles` rather than being
+  # re-encoded as Nix attrs.
+  fluxManifests = pkgs.runCommand "rosequartz-flux-manifests" { } ''
     mkdir -p $out
     cp ${componentsManifest} $out/gotk-components.yaml
     cat ${sourceManifest} ${kustomizationManifest} > $out/gotk-sync.yaml
-    cat > $out/kustomization.yaml <<'EOF'
-    apiVersion: kustomize.config.k8s.io/v1beta1
-    kind: Kustomization
-    resources:
-      - gotk-components.yaml
-      - gotk-sync.yaml
-    EOF
   '';
 
-  imageName = "rosequartz-flux-bootstrap";
-  imageTag = "latest";
-
-  # Image is built and preloaded locally (services.kubernetes.kubelet.seedDockerImages
-  # below) — no registry, no internet access needed on the node at runtime.
-  image = pkgs.dockerTools.buildLayeredImage {
-    name = imageName;
-    tag = imageTag;
-    contents = [
-      pkgs.kubectl
-      pkgs.busybox
-    ];
-    extraCommands = ''
-      mkdir -p manifests
-      cp ${componentsManifest} manifests/gotk-components.yaml
-      cat ${sourceManifest} ${kustomizationManifest} > manifests/gotk-sync.yaml
-      cat > manifests/kustomization.yaml <<'EOF'
-      apiVersion: kustomize.config.k8s.io/v1beta1
-      kind: Kustomization
-      resources:
-        - gotk-components.yaml
-        - gotk-sync.yaml
-      EOF
-    '';
-    config.Entrypoint = [
-      "/bin/sh"
-      "-c"
-      ''
-        while true; do
-          kubectl \
-            --server=https://${cfg.vip}:6443 \
-            --certificate-authority=/pki/ca.crt \
-            --client-certificate=/pki/admin.crt \
-            --client-key=/pki/admin.key \
-            apply -k /manifests
-          sleep 300
-        done
-      ''
-    ];
-  };
+  # nixpkgs computes these attrs (coredns, RBAC bootstrap) regardless of
+  # addonManager.enable, which rosequartz keeps false. Hand them to
+  # inoculant instead of running kube-addon-manager.
+  addonManifests =
+    config.services.kubernetes.addonManager.addons
+    // config.services.kubernetes.addonManager.bootstrapAddons;
 in
 {
-  options.cluster.rosequartz.fluxBootstrap = {
-    enable = lib.mkEnableOption "flux bootstrap static pod";
+  imports = [ inputs.inoculant.nixosModules.default ];
 
-    manifests = lib.mkOption {
-      type = lib.types.package;
-      readOnly = true;
-      internal = true;
-      description = "Generated gotk manifest bundle, for inspection or copying into the-cluster repo.";
-      default = manifests;
-    };
+  options.cluster.rosequartz.fluxBootstrap = {
+    enable = lib.mkEnableOption "coredns + flux bootstrap via inoculant";
   };
 
-  config = lib.mkIf config.cluster.rosequartz.fluxBootstrap.enable {
-    clan.core.vars.generators = {
-      "rosequartz-admin-cert" = lib.mkDefault (
-        pki.mkSharedCert "/CN=kubernetes-admin/O=system:masters" pki.clientExt "kubernetes"
-      );
+  config = lib.mkIf cfg.fluxBootstrap.enable {
+    cluster.rosequartz.pki.certs.inoculant-cert = {
+      cn = "inoculant";
+      org = "system:masters";
+      profile = "client";
+      owner = "kubernetes";
     };
 
-    services.kubernetes.kubelet.seedDockerImages = [ image ];
+    # inoculant's own module generates this cert via nixpkgs' certmgr-based
+    # easyCerts flow, which rosequartz doesn't run (easyCerts = false).
+    # Point it at our own cfssl-issued cert instead. `pki.certs` is a plain
+    # `attrs`-typed option (not attrsOf submodule), so mkForce only takes
+    # effect on the whole assignment — nested `.inoculant = mkForce {...}`
+    # doesn't get unwrapped since inoculant's module also writes this key.
+    services.kubernetes.pki.certs = lib.mkForce {
+      inoculant = {
+        cert = cfg.pki.certs."inoculant-cert".cert;
+        key = cfg.pki.certs."inoculant-cert".key;
+      };
+    };
 
-    # Idempotently re-applies the gotk manifests every 5 minutes. Once Flux's
-    # own controllers are up they reconcile from the-cluster on their own;
-    # this pod just keeps drift-correcting (e.g. if flux-system is deleted)
-    # for free, with no manual bootstrap step required after deploy.
-    services.kubernetes.kubelet.manifests."rosequartz-flux-bootstrap" = {
-      apiVersion = "v1";
-      kind = "Pod";
-      metadata = {
-        name = "rosequartz-flux-bootstrap";
-        namespace = "kube-system";
-      };
-      spec = {
-        restartPolicy = "Always";
-        containers = [
-          {
-            name = "apply";
-            image = "${imageName}:${imageTag}";
-            imagePullPolicy = "Never";
-            volumeMounts = [
-              {
-                name = "ca-crt";
-                mountPath = "/pki/ca.crt";
-                readOnly = true;
-              }
-              {
-                name = "admin-crt";
-                mountPath = "/pki/admin.crt";
-                readOnly = true;
-              }
-              {
-                name = "admin-key";
-                mountPath = "/pki/admin.key";
-                readOnly = true;
-              }
-            ];
-          }
-        ];
-        volumes = [
-          {
-            name = "ca-crt";
-            hostPath = {
-              path = cfg.pki.ca.cert;
-              type = "File";
-            };
-          }
-          {
-            name = "admin-crt";
-            hostPath = {
-              path = cfg.pki.certs."admin-cert".cert;
-              type = "File";
-            };
-          }
-          {
-            name = "admin-key";
-            hostPath = {
-              path = cfg.pki.certs."admin-cert".key;
-              type = "File";
-            };
-          }
-        ];
-      };
+    services.kubernetes.inoculant = {
+      enable = true;
+      manifests = addonManifests;
+      manifestFiles = [ fluxManifests ];
     };
   };
 }


### PR DESCRIPTION
## Summary
- rosequartz's manual PKI (`easyCerts = false`) and disabled `addonManager` left no way to apply CoreDNS or bootstrap Flux without hand-rolled static pods.
- Wires up [inoculant](https://github.com/UnstoppableMango/inoculant) instead: harvests CoreDNS + RBAC bootstrap manifests that nixpkgs already computes (`services.kubernetes.addonManager.{addons,bootstrapAddons}`), issues inoculant its own rosequartz-issued PKI cert, and hands it the Flux gotk manifests (still built via `a2b`) through inoculant's new `manifestFiles` option ([inoculant#13](https://github.com/UnstoppableMango/inoculant/pull/13), already merged).
- `flux.nix` is now actually imported into `control-plane.nix` (it previously wasn't wired up anywhere).
- `cluster.rosequartz.fluxBootstrap.enable` still defaults to `false` — not turned on for any real machine in `clan.nix` yet.

## Test plan
- [x] `nix fmt` — no changes
- [x] Evaluated `nixosConfigurations.pik8s4` with `fluxBootstrap.enable = true` via `extendModules`: confirmed `inoculant.manifests` resolves to the expected coredns + RBAC keys, `manifestFiles` carries the Flux gotk bundle, and the rosequartz-issued `inoculant` cert path threads through correctly (overriding nixpkgs' own certmgr-based cert wiring, which rosequartz doesn't use).
- [ ] Needs `clan vars generate` for the new `rosequartz-inoculant-cert` before `fluxBootstrap.enable` can actually be turned on for a real machine.
