### PR TITLE
chore: update dotfiles input

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -264,11 +264,11 @@
         "zed": "zed"
       },
       "locked": {
-        "lastModified": 1784211433,
-        "narHash": "sha256-hy6/eCdHRDQc1gYFAiVB5sSr80fv+P59IBoJB185kVY=",
+        "lastModified": 1784260642,
+        "narHash": "sha256-8dUIxqVzY1176Ks5B9JTZyhG+AbRRAbPDjQd3tbTWC0=",
         "owner": "unstoppablemango",
         "repo": "dotfiles",
-        "rev": "3b8b3ca282b0438a289e5d1e980d281e2303edff",
+        "rev": "ae6a6fdee0b4e81dffb3b1ef62e742bc7c42bc9a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Summary
- Bumps `dotfiles` flake input to pull in gpg signingkey fix (UnstoppableMango/dotfiles@ae6a6fd)
- Root cause: `commit.gpgsign=true` set with no `user.signingkey`, so git fell back to matching committer identity string against gpg key UIDs. Old RSA key's UID matched `user.name`; current ed25519 key's UID (`Erik Rasmussen`) doesn't match `user.name` (`UnstoppableMango`), breaking signing.

## Test plan
- [ ] `make system` rebuilds and applies new `user.signingkey`
- [ ] New commits sign without explicit `-S<key>` override

🤖 Generated with [Claude Code](https://claude.com/claude-code)