### PR TITLE
Add envfs to provide FHS /bin/bash

### DIFF
--- a/machines/hades/configuration.nix
+++ b/machines/hades/configuration.nix
@@ -453,6 +453,11 @@
   services.lldpd.enable = true;
   services.openssh.enable = true;
 
+  # Provide /bin/bash (and other FHS paths) so tools that hardcode /bin/bash work.
+  # Workaround for GitHub Copilot CLI's bash tool on NixOS.
+  # https://github.com/github/copilot-cli/issues/3392
+  services.envfs.enable = true;
+
   security.pki.certificates = [
     # thecluster.lan Nginx CA
     ''


### PR DESCRIPTION
Enables the envfs service to provide standard FHS paths like /bin/bash.
This resolves issues with tools like GitHub Copilot CLI that hardcode
/bin/bash on NixOS.
See: https://github.com/github/copilot-cli/issues/3392
