### PR TITLE
Refactor modules for increased configurability and clarity

### DIFF
--- a/clan.nix
+++ b/clan.nix
@@ -195,11 +195,13 @@
 
   machines =
     let
+      sshKeys = [
+        "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIEwW6dUPKvKXXzj+gKJS7EXh6UzyLjzatrcPXa0Y2qvz erik@hades"
+        "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDB02UwohkEJGpb8Uud4bNQa73X9WvwQcbsRr1M8c7nztbnUCCeLBTyCtRTMnR6dmoQ3xfGLbv55nlTFT/s6ZZKWEAql/gPJoBF9nEr0622IJQ6VPIpgcI8eA2YDwYA0l19Bji4u3VbTMB+M3Tz7JRmKqHo5bUvnZWi2cp+G5Hh2f2k0lQOa9ttjvVlLBQLCJV8NmCxikJS0ZuH2+KJPT2DVsY8dMZ2fQHh1/DI+ZAo6V1qjEU4SQKjpdIrUsPt9Ah1CBU7W3tG57+aYCoaay/BuUY4zlewxGdn3MAv/mjyqF6WgkzCilr7VBnO8CUgzLGu6F+8ljEJVZ5zqyTGfuni/069qMROEp6abhQe7MGToqFgsDkIJhSihomUNylM2piVFobZTeqGBXqh8h3W1fkQHsfMjYbkYP6kHx7yZ03Xw7X+4ZfySZ4s1PqvJE1ZALHdpzYSDK06+iqbJ3ZA/lpipg+Mzx7iRrD3CsPjzgi1iE6w5DVu5xAMIZIRFetTIAs= erik@darter"
+      ];
+
       pik8s = idx: {
-        users.users.root.openssh.authorizedKeys.keys = [
-          "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIEwW6dUPKvKXXzj+gKJS7EXh6UzyLjzatrcPXa0Y2qvz erik@hades"
-          "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDB02UwohkEJGpb8Uud4bNQa73X9WvwQcbsRr1M8c7nztbnUCCeLBTyCtRTMnR6dmoQ3xfGLbv55nlTFT/s6ZZKWEAql/gPJoBF9nEr0622IJQ6VPIpgcI8eA2YDwYA0l19Bji4u3VbTMB+M3Tz7JRmKqHo5bUvnZWi2cp+G5Hh2f2k0lQOa9ttjvVlLBQLCJV8NmCxikJS0ZuH2+KJPT2DVsY8dMZ2fQHh1/DI+ZAo6V1qjEU4SQKjpdIrUsPt9Ah1CBU7W3tG57+aYCoaay/BuUY4zlewxGdn3MAv/mjyqF6WgkzCilr7VBnO8CUgzLGu6F+8ljEJVZ5zqyTGfuni/069qMROEp6abhQe7MGToqFgsDkIJhSihomUNylM2piVFobZTeqGBXqh8h3W1fkQHsfMjYbkYP6kHx7yZ03Xw7X+4ZfySZ4s1PqvJE1ZALHdpzYSDK06+iqbJ3ZA/lpipg+Mzx7iRrD3CsPjzgi1iE6w5DVu5xAMIZIRFetTIAs= erik@darter"
-        ];
+        users.users.root.openssh.authorizedKeys.keys = sshKeys;
       };
     in
     {
@@ -215,18 +217,12 @@
         ];
         # TODO: re-enable once we've reviewed the networkd/doc-stripping defaults
         clan.core.enableRecommendedDefaults = false;
-        users.users.root.openssh.authorizedKeys.keys = [
-          "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIEwW6dUPKvKXXzj+gKJS7EXh6UzyLjzatrcPXa0Y2qvz erik@hades"
-          "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDB02UwohkEJGpb8Uud4bNQa73X9WvwQcbsRr1M8c7nztbnUCCeLBTyCtRTMnR6dmoQ3xfGLbv55nlTFT/s6ZZKWEAql/gPJoBF9nEr0622IJQ6VPIpgcI8eA2YDwYA0l19Bji4u3VbTMB+M3Tz7JRmKqHo5bUvnZWi2cp+G5Hh2f2k0lQOa9ttjvVlLBQLCJV8NmCxikJS0ZuH2+KJPT2DVsY8dMZ2fQHh1/DI+ZAo6V1qjEU4SQKjpdIrUsPt9Ah1CBU7W3tG57+aYCoaay/BuUY4zlewxGdn3MAv/mjyqF6WgkzCilr7VBnO8CUgzLGu6F+8ljEJVZ5zqyTGfuni/069qMROEp6abhQe7MGToqFgsDkIJhSihomUNylM2piVFobZTeqGBXqh8h3W1fkQHsfMjYbkYP6kHx7yZ03Xw7X+4ZfySZ4s1PqvJE1ZALHdpzYSDK06+iqbJ3ZA/lpipg+Mzx7iRrD3CsPjzgi1iE6w5DVu5xAMIZIRFetTIAs= erik@darter"
-        ];
+        users.users.root.openssh.authorizedKeys.keys = sshKeys;
       };
 
       agreus = {
         imports = [ ./machines/agreus/configuration.nix ];
-        users.users.root.openssh.authorizedKeys.keys = [
-          "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIEwW6dUPKvKXXzj+gKJS7EXh6UzyLjzatrcPXa0Y2qvz erik@hades"
-          "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDB02UwohkEJGpb8Uud4bNQa73X9WvwQcbsRr1M8c7nztbnUCCeLBTyCtRTMnR6dmoQ3xfGLbv55nlTFT/s6ZZKWEAql/gPJoBF9nEr0622IJQ6VPIpgcI8eA2YDwYA0l19Bji4u3VbTMB+M3Tz7JRmKqHo5bUvnZWi2cp+G5Hh2f2k0lQOa9ttjvVlLBQLCJV8NmCxikJS0ZuH2+KJPT2DVsY8dMZ2fQHh1/DI+ZAo6V1qjEU4SQKjpdIrUsPt9Ah1CBU7W3tG57+aYCoaay/BuUY4zlewxGdn3MAv/mjyqF6WgkzCilr7VBnO8CUgzLGu6F+8ljEJVZ5zqyTGfuni/069qMROEp6abhQe7MGToqFgsDkIJhSihomUNylM2piVFobZTeqGBXqh8h3W1fkQHsfMjYbkYP6kHx7yZ03Xw7X+4ZfySZ4s1PqvJE1ZALHdpzYSDK06+iqbJ3ZA/lpipg+Mzx7iRrD3CsPjzgi1iE6w5DVu5xAMIZIRFetTIAs= erik@darter"
-        ];
+        users.users.root.openssh.authorizedKeys.keys = sshKeys;
       };
 
       pik8s1 = pik8s 1;

--- a/machines/hades/configuration.nix
+++ b/machines/hades/configuration.nix
@@ -1,4 +1,7 @@
 { inputs, pkgs, ... }:
+let
+  primaryUser = "erik";
+in
 {
   nix.settings = {
     extra-substituters = [
@@ -20,7 +23,7 @@
 
     system-features = [ "kvm" ];
 
-    trusted-users = [ "erik" ];
+    trusted-users = [ primaryUser ];
   };
 
   nix = {
@@ -193,8 +196,8 @@
 
   # Enable KVM virtualization support
   programs.virt-manager.enable = true;
-  users.groups.libvirtd.members = [ "erik" ];
-  users.groups.libvirt.members = [ "erik" ];
+  users.groups.libvirtd.members = [ primaryUser ];
+  users.groups.libvirt.members = [ primaryUser ];
   virtualisation.libvirtd.enable = true;
   virtualisation.spiceUSBRedirection.enable = true;
 
@@ -251,6 +254,7 @@
   users.defaultUserShell = pkgs.bash;
 
   host.gnome.enable = true;
+  shells.ssh.inhibitSleepOnSsh.enable = true;
 
   home-manager = {
     useGlobalPkgs = true;
@@ -259,7 +263,7 @@
     extraSpecialArgs = { inherit (inputs.dotfiles) inputs; };
   };
 
-  home-manager.users.erik = {
+  home-manager.users.${primaryUser} = {
     imports = with inputs; [
       dotfiles.homeModules.erik
       sops-nix.homeManagerModules.sops
@@ -277,16 +281,16 @@
     # erik's personal age key (public half tracked at sops/users/erik/key.json)
     # is a recipient on the rosequartz-admin-cert secret, unlike hades' own
     # machine key — this is a user secret, not a host one.
-    sops.age.keyFile = "/home/erik/.config/sops/age/keys.txt";
+    sops.age.keyFile = "/home/${primaryUser}/.config/sops/age/keys.txt";
     sops.secrets."rosequartz-admin-key" = {
       sopsFile = ../../vars/shared/rosequartz-admin-cert/key/secret;
       key = "data";
       format = "json";
-      path = "/home/erik/.kube/rosequartz-admin.key";
+      path = "/home/${primaryUser}/.kube/rosequartz-admin.key";
     };
 
     sops.templates."kube-config" = {
-      path = "/home/erik/.kube/config";
+      path = "/home/${primaryUser}/.kube/config";
       mode = "0600";
       content = ''
         apiVersion: v1
@@ -310,7 +314,7 @@
         - name: rosequartz-admin
           user:
             client-certificate: ${../../vars/shared/rosequartz-admin-cert/crt/value}
-            client-key: /home/erik/.kube/rosequartz-admin.key
+            client-key: /home/${primaryUser}/.kube/rosequartz-admin.key
         - name: rosequartz-github
           user:
             exec:
@@ -329,7 +333,7 @@
     };
   };
 
-  users.users.erik = {
+  users.users.${primaryUser} = {
     shell = pkgs.zsh;
     description = "Erik Rasmussen";
     extraGroups = [
@@ -342,7 +346,7 @@
 
   # Enable automatic login for the user.
   services.displayManager.autoLogin.enable = true;
-  services.displayManager.autoLogin.user = "erik";
+  services.displayManager.autoLogin.user = primaryUser;
 
   # https://github.com/NixOS/nixpkgs/issues/240444#issuecomment-1977617644
   programs.nix-ld.enable = true;

--- a/modules/hardware/nvidia/default.nix
+++ b/modules/hardware/nvidia/default.nix
@@ -3,14 +3,16 @@
   options.dotfiles.nvidia.enable = lib.mkEnableOption "NVidia";
 
   config = lib.mkIf config.dotfiles.nvidia.enable {
-    # Open drivers (NVreg_OpenRmEnableUnsupportedGpus=1)
-    open = true;
+    hardware.nvidia = {
+      # Open drivers (NVreg_OpenRmEnableUnsupportedGpus=1)
+      open = true;
 
-    # nvidia-drm.modeset=1
-    modesetting.enable = true;
+      # nvidia-drm.modeset=1
+      modesetting.enable = true;
 
-    # Preserve video memory after suspend
-    # NVreg_PreserveVideoMemoryAllocations=1
-    powerManagement.enable = true;
+      # Preserve video memory after suspend
+      # NVreg_PreserveVideoMemoryAllocations=1
+      powerManagement.enable = true;
+    };
   };
 }

--- a/modules/service/k3s/default.nix
+++ b/modules/service/k3s/default.nix
@@ -5,11 +5,52 @@
 
   roles.worker = {
     description = "Kubernetes worker node";
-    perInstance.nixosModule = ./worker.nix;
+
+    interface =
+      { lib, ... }:
+      {
+        options.serverAddr = lib.mkOption {
+          type = lib.types.str;
+          description = "URL of the k3s control plane server this worker joins (e.g. https://10.0.0.1:6443).";
+        };
+      };
+
+    perInstance =
+      { settings, ... }:
+      {
+        nixosModule = {
+          imports = [ ./worker.nix ];
+          services.k3s.serverAddr = settings.serverAddr;
+        };
+      };
   };
 
   roles.control-plane = {
     description = "Kubernetes control plane node";
-    perInstance.nixosModule = ./control-plane.nix;
+
+    interface =
+      { lib, ... }:
+      {
+        options.serverAddr = lib.mkOption {
+          type = lib.types.str;
+          description = "URL this node advertises as the k3s control plane server (e.g. https://10.0.0.1:6443).";
+        };
+
+        options.tlsSans = lib.mkOption {
+          type = lib.types.listOf lib.types.str;
+          default = [ ];
+          description = "Additional --tls-san entries (e.g. other control plane IPs/hostnames) for the apiserver cert.";
+        };
+      };
+
+    perInstance =
+      { settings, ... }:
+      {
+        nixosModule = {
+          imports = [ ./control-plane.nix ];
+          services.k3s.serverAddr = settings.serverAddr;
+          services.k3s.extraFlags = map (san: "--tls-san=${san}") settings.tlsSans;
+        };
+      };
   };
 }

--- a/modules/service/k3s/k3s.nix
+++ b/modules/service/k3s/k3s.nix
@@ -20,12 +20,9 @@ in
   # https://search.nixos.org/options?channel=unstable&query=k3s
   services.k3s = {
     enable = true;
-    serverAddr = "https://192.168.1.100:6443";
     tokenFile = k3s-token.files.token.path;
 
     extraFlags = [
-      "--tls-san=192.168.1.104" # Match the existing config
-      "--tls-san=192.168.1.100"
       "--disable-cloud-controller"
       "--disable-helm-controller"
       "--disable-network-policy"

--- a/modules/service/pi/4b.nix
+++ b/modules/service/pi/4b.nix
@@ -48,11 +48,5 @@ in
     raspberrypi-eeprom
   ];
 
-  networking = {
-    useDHCP = false;
-    nameservers = [
-      "192.168.1.46"
-      "192.168.1.47"
-    ];
-  };
+  networking.useDHCP = false;
 }

--- a/modules/service/pi/default.nix
+++ b/modules/service/pi/default.nix
@@ -5,10 +5,27 @@
 
   roles.pi4b = {
     description = "Raspberry Pi 4B";
-    perInstance =
-      { ... }:
+
+    interface =
+      { lib, ... }:
       {
-        nixosModule = ./4b.nix;
+        options.nameservers = lib.mkOption {
+          type = lib.types.listOf lib.types.str;
+          default = [
+            "192.168.1.46"
+            "192.168.1.47"
+          ];
+          description = "Nameservers for this Pi 4B.";
+        };
+      };
+
+    perInstance =
+      { settings, ... }:
+      {
+        nixosModule = {
+          imports = [ ./4b.nix ];
+          networking.nameservers = settings.nameservers;
+        };
       };
   };
 }

--- a/modules/shells/ssh/default.nix
+++ b/modules/shells/ssh/default.nix
@@ -3,7 +3,12 @@
 #
 # ... and now UnstoppableMango
 
-{ pkgs, ... }:
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
 
 let
   PID_PATH = "/tmp/ssh_sleep_block.pid";
@@ -66,7 +71,12 @@ let
   '';
 in
 {
-  security.pam.services.sshd.text = pkgs.lib.mkDefault (
-    pkgs.lib.mkAfter "# Prevent sleep on active SSH\nsession optional pam_exec.so quiet ${ssh_script}"
-  );
+  options.shells.ssh.inhibitSleepOnSsh.enable =
+    lib.mkEnableOption "blocking system sleep while an SSH session is active";
+
+  config = lib.mkIf config.shells.ssh.inhibitSleepOnSsh.enable {
+    security.pam.services.sshd.text = pkgs.lib.mkDefault (
+      pkgs.lib.mkAfter "# Prevent sleep on active SSH\nsession optional pam_exec.so quiet ${ssh_script}"
+    );
+  };
 }


### PR DESCRIPTION
Refactor `k3s` and `pi` roles to accept configuration parameters for server addresses, TLS SANs, and nameservers.
Deduplicate SSH authorized keys and introduce a `primaryUser` variable for user declarations.
Update the `nvidia` module's structure and make SSH sleep inhibition an optional feature.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>